### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/pkg/message/http.go
+++ b/pkg/message/http.go
@@ -190,6 +190,11 @@ func readChunkedBody(reader *bufio.Reader, dst *bytes.Buffer) error {
 			return fmt.Errorf("invalid chunk size: %s", line)
 		}
 
+		// Ensure chunkSize is within the range of int
+		if chunkSize < math.MinInt || chunkSize > math.MaxInt {
+			return fmt.Errorf("chunk size out of range: %d", chunkSize)
+		}
+
 		// Zero-sized chunk means end of content
 		if chunkSize == 0 {
 			// Read the final CRLF


### PR DESCRIPTION
Potential fix for [https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/1](https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/1)

To fix the issue, we need to ensure that the conversion from `int64` to `int` is safe. This can be achieved by adding explicit bounds checks before performing the conversion. Specifically:
1. Verify that the `chunkSize` value is within the range of the `int` type (e.g., `math.MinInt` to `math.MaxInt`).
2. If the value is out of bounds, return an appropriate error to prevent further processing.

The fix will involve:
- Adding bounds checks for `chunkSize` after parsing it with `strconv.ParseInt`.
- Ensuring that the bounds checks are performed before any conversion to `int`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
