### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/pkg/message/http.go
+++ b/pkg/message/http.go
@@ -209,6 +209,11 @@ func readChunkedBody(reader *bufio.Reader, dst *bytes.Buffer) error {
 		}
 
 		// Create small buffer for limited reads
+		// Check if chunkSize is within the range of the int type
+		if chunkSize < int64(^uint(0)>>1)*-1 || chunkSize > int64(^uint(0)>>1) {
+			return fmt.Errorf("chunk size out of range for int type: %d", chunkSize)
+		}
+
 		bufSize := int(chunkSize)
 		if bufSize > 8192 {
 			bufSize = 8192


### PR DESCRIPTION
Potential fix for [https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/2](https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/2)

To fix the issue, we need to ensure that the value of `chunkSize` is within the valid range of the `int` type before performing the conversion. This can be achieved by adding explicit bounds checks for the `chunkSize` value. The bounds should depend on the platform-specific size of the `int` type. 

The `math` package provides constants `math.MaxInt32` and `math.MinInt32` for 32-bit systems, and `math.MaxInt64` and `math.MinInt64` for 64-bit systems. We can use these constants to determine the appropriate bounds dynamically based on the size of the `int` type.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
