### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/pkg/message/http.go
+++ b/pkg/message/http.go
@@ -190,6 +190,11 @@ func readChunkedBody(reader *bufio.Reader, dst *bytes.Buffer) error {
 			return fmt.Errorf("invalid chunk size: %s", line)
 		}
 
+		// Check if chunkSize is within the range of int
+		if chunkSize < math.MinInt || chunkSize > math.MaxInt {
+			return fmt.Errorf("chunk size out of range: %d", chunkSize)
+		}
+
 		// Zero-sized chunk means end of content
 		if chunkSize == 0 {
 			// Read the final CRLF


### PR DESCRIPTION
Potential fix for [https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/3](https://github.com/Xerolux/tcp-multiplexer/security/code-scanning/3)

To fix the issue, we need to ensure that the value of `chunkSize` is within the valid range of the `int` type before performing the conversion. This can be achieved by adding explicit bounds checks using the constants `math.MaxInt` and `math.MinInt` from the `math` package. If the value is out of range, the function should return an appropriate error.

The changes will be made in the `pkg/message/http.go` file:
1. Add bounds checks for `chunkSize` after parsing it with `strconv.ParseInt`.
2. Only proceed with the conversion to `int` if the value is within the valid range.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
